### PR TITLE
fix(ci): add secrets inherit to image workflow call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,4 @@ jobs:
   image:
     needs: code
     uses: ./.github/workflows/test_image.yml
+    secrets: inherit


### PR DESCRIPTION
Add `secrets: inherit` to the `image` job in `ci.yml` which calls `test_image.yml`. This fixes the "Secret CODECOV_TOKEN is required, but not provided while calling" error and matches the existing pattern used for the `code` job.