### PR TITLE
fix(ci): remove unnecessary secrets inherit from image job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,3 @@ jobs:
   image:
     needs: code
     uses: ./.github/workflows/test_image.yml
-    secrets: inherit


### PR DESCRIPTION
Removes the `secrets: inherit` from the image workflow call as it's not needed. The test_image.yml workflow doesn't require any secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to refine secret handling in the image job.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->