### PR TITLE
chore: remove redundant default values from coderabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,12 +1,9 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 ---
-language: en-US
 tone_instructions: "Be direct and concise. Focus on correctness of semver logic and conventional commit parsing."
-early_access: true
 
 reviews:
   auto_review:
-    enabled: true
     drafts: false
   path_instructions:
     - path: src/bumper.js
@@ -45,6 +42,3 @@ reviews:
         - Correct trigger conditions
         - Proper use of reusable workflows
         - Security (minimal permissions)
-
-chat:
-  auto_reply: true


### PR DESCRIPTION
Removes redundant default values from CodeRabbit configuration:
- `language: en-US` (default)
- `early_access: true` (default is false, but this was set to true unnecessarily)
- `auto_review.enabled: true` (default)
- `auto_reply: true` (default)

Keeps only non-default settings and project-specific configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings to streamline tooling setup and remove unused options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->