### PR TITLE
docs: standardize code of conduct enforcement section

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -53,7 +53,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team via GitHub. All complaints will
+reported by messaging the project maintainers directly via their GitHub profiles. All complaints will
 be reviewed and investigated and will result in a response that is deemed
 necessary and appropriate to the circumstances. The project team is obligated
 to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
## Summary
- Standardize CODE_OF_CONDUCT.md enforcement section to match switcher_webapi and version-bumper-action
- Changes wording from "contacting the project team via GitHub" to "messaging the project maintainers directly via their GitHub profiles"

## Purpose
Maintain consistency across all projects for how to report code of conduct violations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Code of Conduct with revised complaint reporting process.
  * Added clarification that additional enforcement policy details may be posted separately.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->