### PR TITLE
fix: override @conventional-changelog/git-client to ^2.0.0 for CVE-2025-59433

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,8 @@
         "shelljs": "^0.10.0"
       },
       "engines": {
-        "node": ">= 18.0.0",
-        "npm": ">= 9.0.0"
+        "node": ">= 20.0.0",
+        "npm": ">= 10.0.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -44,11 +44,13 @@
       }
     },
     "node_modules/@conventional-changelog/git-client": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-1.0.1.tgz",
-      "integrity": "sha512-PJEqBwAleffCMETaVm/fUgHldzBE35JFk3/9LL6NUA5EXa3qednu+UT6M7E5iBu3zIQZCULYIiZ90fBYHt6xUw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.5.1.tgz",
+      "integrity": "sha512-lAw7iA5oTPWOLjiweb7DlGEMDEvzqzLLa6aWOly2FSZ64IwLE8T458rC+o+WvI31Doz6joM7X2DoNog7mX8r4A==",
+      "license": "MIT",
       "dependencies": {
-        "@types/semver": "^7.5.5",
+        "@simple-libs/child-process-utils": "^1.0.0",
+        "@simple-libs/stream-utils": "^1.1.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -56,7 +58,7 @@
       },
       "peerDependencies": {
         "conventional-commits-filter": "^5.0.0",
-        "conventional-commits-parser": "^6.0.0"
+        "conventional-commits-parser": "^6.1.0"
       },
       "peerDependenciesMeta": {
         "conventional-commits-filter": {
@@ -514,11 +516,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -1012,32 +1009,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/@conventional-changelog/git-client": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.5.1.tgz",
-      "integrity": "sha512-lAw7iA5oTPWOLjiweb7DlGEMDEvzqzLLa6aWOly2FSZ64IwLE8T458rC+o+WvI31Doz6joM7X2DoNog7mX8r4A==",
-      "license": "MIT",
-      "dependencies": {
-        "@simple-libs/child-process-utils": "^1.0.0",
-        "@simple-libs/stream-utils": "^1.1.0",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "conventional-commits-filter": "^5.0.0",
-        "conventional-commits-parser": "^6.1.0"
-      },
-      "peerDependenciesMeta": {
-        "conventional-commits-filter": {
-          "optional": true
-        },
-        "conventional-commits-parser": {
-          "optional": true
-        }
       }
     },
     "node_modules/convert-source-map": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
   "overrides": {
     "c8": {
       "yargs": "^18.0.0"
+    },
+    "git-semver-tags": {
+      "@conventional-changelog/git-client": "^2.0.0"
     }
   },
   "c8": {


### PR DESCRIPTION
## Summary

- Override `@conventional-changelog/git-client` to `^2.0.0` for `git-semver-tags` to fix [CVE-2025-59433](https://github.com/TomerFi/version-bumper/security/dependabot/8) (argument injection via `getTags()` API)
- `git-semver-tags@8.0.0` (latest) still depends on `^1.0.0` which resolves to vulnerable `1.0.1` — no upstream fix available
- Tracking removal of override in #393

## Test plan

- [x] `npm ls @conventional-changelog/git-client` confirms both paths resolve to `2.5.1`
- [x] All 13 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints to ensure consistent project tooling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->