### PR TITLE
fix(release): restore deploy key for git push bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Install node 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e


### PR DESCRIPTION
## Summary
- Re-adds `ssh-key` secret to the `checkout` step in `release.yml`
- Deploy key enables `git push` to bypass branch protection rules on master
- Without it, direct git pushes to master are rejected due to "changes must be made through a pull request" rule